### PR TITLE
Deleted .question-wrapper from question.pstpl in default template. #23

### DIFF
--- a/templates/default/views/question.pstpl
+++ b/templates/default/views/question.pstpl
@@ -2,7 +2,7 @@
     <div {QUESTION_ESSENTIALS} class="{QUESTION_CLASS}{QUESTION_MAN_CLASS}{QUESTION_INPUT_ERROR_CLASS} col-xs-12 question-container">
 
         <!-- Question title -->
-        <div class="row question-wrapper question-title-container">
+        <div class="row question-title-container">
             <div class="col-sm-12 questiontext">
                 <div class="qnumcode question-text">
                 {QUESTION_MANDATORY}{QUESTION_NUMBER} {QUESTION_CODE}{QUESTION_TEXT}
@@ -12,7 +12,7 @@
         </div>
 
         <!-- Question valid message -->
-        <div class="row question-wrapper">
+        <div class="row">
             <div class="col-sm-12 questionvalidcontainer">
                 {QUESTION_VALID_MESSAGE}
                 {QUESTION_MAN_MESSAGE}
@@ -22,14 +22,14 @@
 
 
         <!-- Answer -->
-        <div class="row question-wrapper answer-container">
+        <div class="row answer-container">
             <div class="col-sm-12 answer">
                 {ANSWER}
             </div>
         </div>
 
         <!-- Question help -->
-        <div class="row question-wrapper question-help-container">
+        <div class="row question-help-container">
             <div class="col-sm-12 question-help">
                 {QUESTIONHELP}
             </div>


### PR DESCRIPTION
Just testing my abilities to do things on your repo. I now made a fork, because I cannot do anything from a clone, it looks like.

This is a small thing on the default template. No visible changes at the front end, since question-wrapper is mentioned in the question.pstpl, but has no entry in template.css or template.js.